### PR TITLE
Crawl to add wof:geom_alt, fix src:geom_alt

### DIFF
--- a/data/421/193/671/421193671.geojson
+++ b/data/421/193/671/421193671.geojson
@@ -186,6 +186,9 @@
     },
     "wof:country":"TV",
     "wof:created":1459009779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57b73e0af041aeb22b02a67069586020",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1566588224,
+    "wof:lastmodified":1582145339,
     "wof:name":"Nanumanga",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/193/675/421193675.geojson
+++ b/data/421/193/675/421193675.geojson
@@ -188,6 +188,9 @@
     },
     "wof:country":"TV",
     "wof:created":1459009779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8cada6673f531dc48dfb3f820724254",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1566588223,
+    "wof:lastmodified":1582145339,
     "wof:name":"Niutao",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/193/677/421193677.geojson
+++ b/data/421/193/677/421193677.geojson
@@ -189,6 +189,9 @@
     },
     "wof:country":"TV",
     "wof:created":1459009779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e78f3ab26420e4781ac5206810a96926",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1566588224,
+    "wof:lastmodified":1582145339,
     "wof:name":"Nukulaelae",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/193/679/421193679.geojson
+++ b/data/421/193/679/421193679.geojson
@@ -180,6 +180,9 @@
     },
     "wof:country":"TV",
     "wof:created":1459009779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"faf1d318b5c7c80ef95b1dbd0ef065da",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1566588224,
+    "wof:lastmodified":1582145339,
     "wof:name":"Nukufetau",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/193/681/421193681.geojson
+++ b/data/421/193/681/421193681.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"TV",
     "wof:created":1459009779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f48ed0233e7d0743b1c7ed7a55b9119c",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1566588224,
+    "wof:lastmodified":1582145339,
     "wof:name":"Nanumea",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/203/363/421203363.geojson
+++ b/data/421/203/363/421203363.geojson
@@ -176,6 +176,9 @@
     },
     "wof:country":"TV",
     "wof:created":1459010148,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da1d70169c8094d879de376f8c2e2c8d",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1566588225,
+    "wof:lastmodified":1582145339,
     "wof:name":"Nui",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/204/425/421204425.geojson
+++ b/data/421/204/425/421204425.geojson
@@ -375,6 +375,9 @@
     },
     "wof:country":"TV",
     "wof:created":1459010186,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ec1cdaa409148177aecaf3335a1974b",
     "wof:hierarchy":[
         {
@@ -392,7 +395,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1566588224,
+    "wof:lastmodified":1582145339,
     "wof:name":"Funafuti",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/856/326/07/85632607.geojson
+++ b/data/856/326/07/85632607.geojson
@@ -851,6 +851,11 @@
     },
     "wof:country":"TV",
     "wof:country_alpha3":"TUV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"7a291813bd7feeb20c09ad189896aab0",
     "wof:hierarchy":[
         {
@@ -867,7 +872,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1566588223,
+    "wof:lastmodified":1582145338,
     "wof:name":"Tuvalu",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/890/428/951/890428951.geojson
+++ b/data/890/428/951/890428951.geojson
@@ -412,7 +412,8 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "quattroshapes_pg",
-        "unknown"
+        "unknown",
+        "naturalearth"
     ],
     "src:population":"geonames",
     "wof:belongsto":[],
@@ -429,6 +430,11 @@
     },
     "wof:country":"TV",
     "wof:created":1469051783,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "unknown",
+        "naturalearth"
+    ],
     "wof:geomhash":"1ec1cdaa409148177aecaf3335a1974b",
     "wof:hierarchy":[
         {
@@ -439,7 +445,7 @@
         }
     ],
     "wof:id":890428951,
-    "wof:lastmodified":1566588226,
+    "wof:lastmodified":1582145339,
     "wof:name":"Funafuti Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. An example of a change to this property can be found in `data/890/428/951/890428951.geojson`

This will not require PIP work to update hierarchies. I want to test this on a handful of other repos before merging, though.