### PR TITLE
tv concordances, placetype local, and more

### DIFF
--- a/data/110/882/640/1/1108826401.geojson
+++ b/data/110/882/640/1/1108826401.geojson
@@ -135,8 +135,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"TV.VI"
+        "hasc:id":"TV.VI",
+        "iso:code":"TV-VAI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TV",
     "wof:geomhash":"4f2deafb5ee2e024ceaf25f4973e3d34",
     "wof:hierarchy":[
@@ -155,7 +157,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884330,
     "wof:name":"Vaitupu",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/193/671/421193671.geojson
+++ b/data/421/193/671/421193671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000333,
-    "geom:area_square_m":4091547.073653,
+    "geom:area_square_m":4091569.124153,
     "geom:bbox":"176.312057,-6.303266,176.327347,-6.272387",
     "geom:latitude":-6.287611,
     "geom:longitude":176.320275,
@@ -191,17 +191,19 @@
         "gn:id":7601980,
         "gp:id":24549916,
         "hasc:id":"TV.NG",
+        "iso:code":"TV-NMG",
         "iso:id":"TV-NMG",
         "qs_pg:id":59707,
         "wd:id":"Q367027",
         "wk:page":"Nanumanga"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TV",
     "wof:created":1459009779,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aa9249dd73ef972741730fca14660d26",
+    "wof:geomhash":"642f019c79ce27a9f930b45514c41651",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -218,7 +220,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1690875662,
+    "wof:lastmodified":1695884330,
     "wof:name":"Nanumanga",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/193/675/421193675.geojson
+++ b/data/421/193/675/421193675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000355,
-    "geom:area_square_m":4348253.77237,
+    "geom:area_square_m":4348300.720239,
     "geom:bbox":"177.330095,-10.766341,179.499473,-6.102006",
     "geom:latitude":-7.747569,
     "geom:longitude":178.09914,
@@ -194,16 +194,18 @@
         "gn:id":7601979,
         "gp:id":24549918,
         "hasc:id":"TV.NT",
+        "iso:code":"TV-NIT",
         "iso:id":"TV-NIT",
         "qs_pg:id":59708,
         "wd:id":"Q475219"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TV",
     "wof:created":1459009779,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"76423440966ff728f90ce2262da37838",
+    "wof:geomhash":"26c4e7666b8f9c1679b07ad74a425858",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -220,7 +222,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1690875661,
+    "wof:lastmodified":1695884330,
     "wof:name":"Niutao",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/193/677/421193677.geojson
+++ b/data/421/193/677/421193677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000763,
-    "geom:area_square_m":9312082.590949,
+    "geom:area_square_m":9312072.765555,
     "geom:bbox":"179.806739,-9.436449,179.872329,-9.346126",
     "geom:latitude":-9.391728,
     "geom:longitude":179.845713,
@@ -188,17 +188,19 @@
         "gn:id":7601983,
         "gp:id":24549920,
         "hasc:id":"TV.NL",
+        "iso:code":"TV-NKL",
         "iso:id":"TV-NKL",
         "qs_pg:id":59710,
         "wd:id":"Q128654",
         "wk:page":"Nukulaelae"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TV",
     "wof:created":1459009779,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e41e80a8873bbd0bda96cf7945404b6",
+    "wof:geomhash":"ef28e131f12da2d147108247f294d9f1",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -215,7 +217,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1690875663,
+    "wof:lastmodified":1695884330,
     "wof:name":"Nukulaelae",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/193/679/421193679.geojson
+++ b/data/421/193/679/421193679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000581,
-    "geom:area_square_m":7118459.425992,
+    "geom:area_square_m":7118418.223724,
     "geom:bbox":"178.305468,-8.074853,178.438006,-7.928192",
     "geom:latitude":-8.018703,
     "geom:longitude":178.378783,
@@ -197,17 +197,19 @@
         "gn:id":7601982,
         "gp:id":24549922,
         "hasc:id":"TV.NF",
+        "iso:code":"TV-NKF",
         "iso:id":"TV-NKF",
         "qs_pg:id":59711,
         "wd:id":"Q745924",
         "wk:page":"Nukufetau"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TV",
     "wof:created":1459009779,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4d84bf2e748b8a1d60b6aa0ab863b073",
+    "wof:geomhash":"772b91a4d8868e20529af5e64148cdfb",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -224,7 +226,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1690875662,
+    "wof:lastmodified":1695884871,
     "wof:name":"Nukufetau",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/193/681/421193681.geojson
+++ b/data/421/193/681/421193681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000517,
-    "geom:area_square_m":6356528.377925,
+    "geom:area_square_m":6356705.246567,
     "geom:bbox":"176.05763,-5.702551,176.137765,-5.641625",
     "geom:latitude":-5.669167,
     "geom:longitude":176.106896,
@@ -224,17 +224,19 @@
         "gn:id":2110345,
         "gp:id":24549924,
         "hasc:id":"TV.NA",
+        "iso:code":"TV-NMA",
         "iso:id":"TV-NMA",
         "qs_pg:id":59713,
         "wd:id":"Q174618",
         "wk:page":"Nanumea"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TV",
     "wof:created":1459009779,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"714fde93dbf821eaf7ef3f6a2451c696",
+    "wof:geomhash":"7d025a00898cec8f2daf2712c73eb135",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -251,7 +253,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1690875662,
+    "wof:lastmodified":1695884871,
     "wof:name":"Nanumea",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/203/363/421203363.geojson
+++ b/data/421/203/363/421203363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000467,
-    "geom:area_square_m":5732033.222866,
+    "geom:area_square_m":5732078.418344,
     "geom:bbox":"177.143162,-7.25324,177.166086,-7.188564",
     "geom:latitude":-7.219687,
     "geom:longitude":177.154555,
@@ -184,17 +184,19 @@
         "gn:id":2110341,
         "gp:id":24549923,
         "hasc:id":"TV.NU",
+        "iso:code":"TV-NUI",
         "iso:id":"TV-NUI",
         "qs_pg:id":59712,
         "wd:id":"Q547997",
         "wk:page":"Nui (atoll)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TV",
     "wof:created":1459010148,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b2bd58274bb0ca568ba7cd86d8accc71",
+    "wof:geomhash":"429b54a4ff8ce44b58b4cd6427471590",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -211,7 +213,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1690875663,
+    "wof:lastmodified":1695884330,
     "wof:name":"Nui",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/421/204/425/421204425.geojson
+++ b/data/421/204/425/421204425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000824,
-    "geom:area_square_m":10071941.17887,
+    "geom:area_square_m":10072049.812025,
     "geom:bbox":"179.036678,-8.641312,179.202766,-8.424814",
     "geom:latitude":-8.524849,
     "geom:longitude":179.149859,
@@ -419,17 +419,19 @@
         "gn:id":2110384,
         "gp:id":24549921,
         "hasc:id":"TV.FN",
+        "iso:code":"TV-FUN",
         "iso:id":"TV-FUN",
         "qs_pg:id":240839,
         "wd:id":"Q34126",
         "wk:page":"Funafuti"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TV",
     "wof:created":1459010186,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e6e45156b34b24b82f8bb93c957bf1e0",
+    "wof:geomhash":"4844fb32c36bb3f0289762b8762ef17c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -446,7 +448,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1690875663,
+    "wof:lastmodified":1695884871,
     "wof:name":"Funafuti",
     "wof:parent_id":85632607,
     "wof:placetype":"region",

--- a/data/856/326/07/85632607.geojson
+++ b/data/856/326/07/85632607.geojson
@@ -1018,6 +1018,7 @@
         "hasc:id":"TV",
         "icao:code":"T2",
         "ioc:id":"TUV",
+        "iso:code":"TV",
         "itu:id":"TUV",
         "m49:code":"798",
         "marc:id":"tv",
@@ -1031,6 +1032,7 @@
         "wk:page":"Tuvalu",
         "wmo:id":"TV"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TV",
     "wof:country_alpha3":"TUV",
     "wof:geom_alt":[
@@ -1054,7 +1056,7 @@
         "tvl",
         "eng"
     ],
-    "wof:lastmodified":1694639668,
+    "wof:lastmodified":1695881328,
     "wof:name":"Tuvalu",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/890/417/405/890417405.geojson
+++ b/data/890/417/405/890417405.geojson
@@ -176,7 +176,7 @@
         }
     ],
     "wof:id":890417405,
-    "wof:lastmodified":1694497771,
+    "wof:lastmodified":1695887148,
     "wof:name":"Niulakita",
     "wof:parent_id":-1,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.